### PR TITLE
Remove schema version

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Fruitcake_AlwaysLoginAsCustomer" setup_version="1.0.0" />
+    <module name="Fruitcake_AlwaysLoginAsCustomer" />
     <sequence>
         <module name="Magento_LoginAsCustomer"/>
     </sequence>


### PR DESCRIPTION
As there is no database schema, there is no reason to declare this. Declaring it forces the user to run setup:upgrade (and causes downtime).